### PR TITLE
Add support for stdio streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ An implementation of an asynchronous process management backed futures.
 [dependencies]
 tokio-core = "0.1"
 futures = "0.1"
+mio = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ An implementation of an asynchronous process management backed futures.
 tokio-core = "0.1"
 futures = "0.1"
 mio = "0.6"
+log = "0.3"
+env_logger = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
@@ -21,4 +23,9 @@ kernel32-sys = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+nix = "0.6"
 tokio-signal = "0.1"
+
+[replace]
+"mio:0.6.1" = { path = "mio" }
+"tokio-core:0.1.1" = { path = "tokio-core" }

--- a/src/bin/cat.rs
+++ b/src/bin/cat.rs
@@ -15,4 +15,5 @@ fn main() {
         }
         stdout.write(line.as_bytes()).unwrap();
     }
+    stdout.flush().unwrap();
 }

--- a/src/bin/cat.rs
+++ b/src/bin/cat.rs
@@ -1,0 +1,18 @@
+// A cat-like utility that can be used as a subprocess to test I/O
+// stream communication.
+use std::io;
+use std::io::Write;
+
+fn main() {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        stdin.read_line(&mut line).unwrap();
+        if line.len() == 0 {
+            break;
+        }
+        stdout.write(line.as_bytes()).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 extern crate futures;
 extern crate tokio_core;
 extern crate mio;
+#[macro_use]
+extern crate log;
 
 use std::ffi::OsStr;
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate futures;
 extern crate tokio_core;
+extern crate mio;
 
 use std::ffi::OsStr;
 use std::io;
@@ -17,6 +18,9 @@ mod imp;
 #[path = "windows.rs"]
 #[cfg(windows)]
 mod imp;
+
+pub use imp::ChildStdin;
+pub use imp::ChildStdout;
 
 pub struct Command {
     inner: process::Command,
@@ -94,6 +98,20 @@ impl Command {
         self
     }
 
+    pub fn stdin(&mut self, cfg: process::Stdio) -> &mut Self {
+        self.inner.stdin(cfg);
+        self
+    }
+
+    pub fn stdout(&mut self, cfg: process::Stdio) -> &mut Self {
+        self.inner.stdout(cfg);
+        self
+    }
+    pub fn stderr(&mut self, cfg: process::Stdio) -> &mut Self {
+        self.inner.stderr(cfg);
+        self
+    }
+
     pub fn spawn(self) -> Spawn {
         Spawn {
             inner: Box::new(imp::spawn(self).map(|c| Child { inner: c })),
@@ -117,6 +135,18 @@ impl Child {
 
     pub fn kill(&mut self) -> io::Result<()> {
         self.inner.kill()
+    }
+
+    pub fn stdin(&mut self) -> &mut Option<imp::ChildStdin> {
+        &mut self.inner.stdin
+    }
+
+    pub fn stdout(&mut self) -> &mut Option<imp::ChildStdout> {
+        &mut self.inner.stdout
+    }
+
+    pub fn stderr(&mut self) -> &mut Option<imp::ChildStderr> {
+        &mut self.inner.stderr
     }
 }
 

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -1,0 +1,85 @@
+extern crate futures;
+#[macro_use]
+extern crate tokio_core;
+extern crate tokio_process;
+
+use std::env;
+use std::io;
+use std::process::Stdio;
+
+use futures::{Future, BoxFuture};
+use futures::stream::{self, Stream};
+use tokio_core::io::{read_until, write_all};
+use tokio_core::reactor::{Core, Handle};
+use tokio_process::{Command, Child};
+
+fn cat(handle: &Handle) -> Command {
+    let mut path = env::current_exe().unwrap();
+    path.pop();
+    path.push("cat");
+    let mut cmd = Command::new(path, handle);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped());
+    cmd
+}
+
+fn feed_cat(cat: &mut Child, n: usize) -> BoxFuture<(), io::Error> {
+    let stdin = cat.stdin().take().unwrap();
+    let stdout = cat.stdout().take().unwrap();
+
+    // Produce n lines on the child's stdout.
+    let numbers = stream::iter((0..n).into_iter().map(Ok));
+    let write = numbers.fold(stdin, |stdin, i| {
+        write_all(stdin, format!("line {}\n", i).into_bytes()).map(|(writer, _)| writer)
+    }).map(|_| {});
+
+    // Try to read `n + 1` lines, ensuring the last one is empty
+    // (i.e. EOF is reached after `n` lines.
+    let reader = io::BufReader::new(stdout);
+    let expected_numbers = stream::iter((0..n + 1).into_iter().map(Ok));
+    let read = expected_numbers.fold((reader, 0), move |(reader, i), _| {
+        let done = i >= n;
+        read_until(reader, b'\n', Vec::new()).and_then(move |(reader, vec)| {
+            match (done, vec.len()) {
+                (false, 0) => {
+                    Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
+                },
+                (true, n) if n != 0 => {
+                    Err(io::Error::new(io::ErrorKind::Other, "extraneous data"))
+                },
+                _ => {
+                    let s = std::str::from_utf8(&vec).unwrap();
+                    let expected = format!("line {}\n", i);
+                    if done || s == expected {
+                        Ok((reader, i + 1))
+                    } else {
+                        Err(io::Error::new(io::ErrorKind::Other, "unexpected data"))
+                    }
+                }
+            }
+        })
+    });
+    // Compose reading and writing concurrently.
+    write.join(read).map(|_| {}).boxed()
+}
+
+#[test]
+/// Check for the following properties when feeding stdin and
+/// consuming stdout of a cat-like process:
+///
+/// - A number of lines that amounts to a number of bytes exceeding a
+///   typical OS buffer size can be fed to the child without
+///   deadlock. This tests that we also consume the stdout
+///   concurrently; otherwise this would deadlock.
+///
+/// - We read the same lines from the child that we fed it.
+//
+/// - The child does produce EOF on stdout after the last line.
+fn cat_loop() {
+    let mut lp = Core::new().unwrap();
+    let cmd = cat(&lp.handle());
+    let mut child = lp.run(cmd.spawn()).unwrap();
+    lp.run(feed_cat(&mut child, 10000)).unwrap();
+    let status = lp.run(&mut child).unwrap();
+    assert_eq!(status.code(), Some(0));
+}


### PR DESCRIPTION
Extend the API, mimicking `std::process` to provide access to stdin,
stdout and stderr of the subprocess.

To demonstrate basic functionality, add a program doing line-based
copying from stdin to stdout, and drive that using the new API in a
new unit test.

Note that the provided implementation is currently for Unix only, due
to lack of familiarity of the author with the Windows platform.