### PR TITLE
Deprecate `Command` and its related methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod imp;
 #[cfg(windows)]
 mod imp;
 
+#[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
 pub struct Command {
     inner: process::Command,
     #[allow(dead_code)]
@@ -32,7 +33,9 @@ pub struct Child {
     inner: imp::Child,
 }
 
+#[allow(deprecated)]
 impl Command {
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn new<T: AsRef<OsStr>>(exe: T, handle: &Handle) -> Command {
         Command::_new(exe.as_ref(), handle)
     }
@@ -44,6 +47,7 @@ impl Command {
         }
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Command {
         self._arg(arg.as_ref())
     }
@@ -53,6 +57,7 @@ impl Command {
         self
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> &mut Command {
         for arg in args {
             self._arg(arg.as_ref());
@@ -60,6 +65,7 @@ impl Command {
         self
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Command
         where K: AsRef<OsStr>, V: AsRef<OsStr>
     {
@@ -71,6 +77,7 @@ impl Command {
         self
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Command {
         self._env_remove(key.as_ref())
     }
@@ -80,11 +87,13 @@ impl Command {
         self
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn env_clear(&mut self) -> &mut Command {
         self.inner.env_clear();
         self
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Command {
         self._current_dir(dir.as_ref())
     }
@@ -94,10 +103,20 @@ impl Command {
         self
     }
 
+    #[deprecated(since = "0.1", note = "use `spawn_cmd` instead")]
     pub fn spawn(self) -> Spawn {
         Spawn {
-            inner: Box::new(imp::spawn(self).map(|c| Child { inner: c })),
+            inner: Box::new(imp::spawn(&self.handle, self.inner).map(|c| Child { inner: c })),
         }
+    }
+}
+
+/// Returns a future which will spawn the provided command when polled.
+///
+/// Also requires an event loop `handle` to drive polling for exited children.
+pub fn spawn_cmd(handle: &Handle, cmd: process::Command) -> Spawn {
+    Spawn {
+        inner: Box::new(imp::spawn(handle, cmd).map(|c| Child { inner: c })),
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,11 +4,10 @@ extern crate kernel32;
 use std::io;
 use std::os::windows::prelude::*;
 use std::os::windows::process::ExitStatusExt;
-use std::process::{self, ExitStatus};
+use std::process::{self, Command, ExitStatus};
+use tokio_core::reactor::Handle;
 
 use futures::{self, Future, Poll, Async, Oneshot, Complete, oneshot, Fuse};
-
-use Command;
 
 pub struct Child {
     child: process::Child,
@@ -24,8 +23,8 @@ struct Waiting {
 unsafe impl Sync for Waiting {}
 unsafe impl Send for Waiting {}
 
-pub fn spawn(mut cmd: Command) -> Box<Future<Item=Child, Error=io::Error>> {
-    Box::new(futures::done(cmd.inner.spawn().map(|c| {
+pub fn spawn(_: &Handle, mut cmd: Command) -> Box<Future<Item=Child, Error=io::Error>> {
+    Box::new(futures::done(cmd.spawn().map(|c| {
         Child {
             child: c,
             waiting: None,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,12 +3,14 @@ extern crate tokio_core;
 extern crate tokio_process;
 
 use std::env;
+use std::process;
 use std::sync::mpsc::channel;
 use std::sync::{Once, ONCE_INIT};
 use std::thread;
 
 use tokio_core::reactor::{Core, Handle};
-use tokio_process::Command;
+#[allow(deprecated)]
+use tokio_process::{Command, spawn_cmd};
 
 static INIT: Once = ONCE_INIT;
 
@@ -17,8 +19,9 @@ fn init() {
         let (tx, rx) = channel();
         thread::spawn(move || {
             let mut lp = Core::new().unwrap();
-            let cmd = exit(&lp.handle());
-            let mut child = lp.run(cmd.spawn()).unwrap();
+            let cmd = exit();
+            let spawn = spawn_cmd(&lp.handle(), cmd);
+            let mut child = lp.run(spawn).unwrap();
             drop(child.kill());
             lp.run(child).unwrap();
             tx.send(()).unwrap();
@@ -28,7 +31,8 @@ fn init() {
     });
 }
 
-fn exit(handle: &Handle) -> Command {
+#[allow(deprecated)]
+fn exit_deprecated(handle: &Handle) -> Command {
     let mut me = env::current_exe().unwrap();
     me.pop();
     if me.ends_with("deps") {
@@ -38,14 +42,42 @@ fn exit(handle: &Handle) -> Command {
     Command::new(me, handle)
 }
 
+fn exit() -> process::Command {
+    let mut me = env::current_exe().unwrap();
+    me.pop();
+    if me.ends_with("deps") {
+        me.pop();
+    }
+    me.push("exit");
+    process::Command::new(me)
+}
+
+#[test]
+#[allow(deprecated)]
+fn simple_deprecated() {
+    init();
+
+    let mut lp = Core::new().unwrap();
+    let mut cmd = exit_deprecated(&lp.handle());
+    cmd.arg("2");
+    let mut child = lp.run(cmd.spawn()).unwrap();
+    let id = child.id();
+    assert!(id > 0);
+    let status = lp.run(&mut child).unwrap();
+    assert_eq!(status.code(), Some(2));
+    assert_eq!(child.id(), id);
+    drop(child.kill());
+}
+
 #[test]
 fn simple() {
     init();
 
     let mut lp = Core::new().unwrap();
-    let mut cmd = exit(&lp.handle());
+    let mut cmd = exit();
     cmd.arg("2");
-    let mut child = lp.run(cmd.spawn()).unwrap();
+    let spawn = spawn_cmd(&lp.handle(), cmd);
+    let mut child = lp.run(spawn).unwrap();
     let id = child.id();
     assert!(id > 0);
     let status = lp.run(&mut child).unwrap();


### PR DESCRIPTION
* The `Command` wrapper only serves to pair an `std::process::Command`
with an event-loop handle and spawn this combination at the cost of
maintaining feature/documentation parity with the `std` implementation
* `Command` has been deprecated in favor of a top level `spawn_cmd`
function which accepts an event-loop handle and an
`std::process::Command` to spawn, bypassing the need for the
intermediate struct
* Unfortunately, even on Windows builds this requires an event-loop
handle (even though the event-loop is not used for polling children),
however, this limitation was already present on the `Command` wrapper,
so there is no functionality regression