### PR TITLE
Add `Debug` impls for nondeprecated structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@
 //! `tokio_process::Child` is dropped. The behavior of the standard library can
 //! be regained with the `Child::forget` method.
 
+#![warn(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/tokio-process/0.1")]
 
@@ -130,6 +131,7 @@ use std::process::{self, ExitStatus, Output, Stdio};
 
 use futures::{Future, Poll, IntoFuture};
 use futures::future::{Flatten, FutureResult, Either, ok};
+use std::fmt;
 use tokio_core::reactor::Handle;
 use tokio_io::io::{read_to_end};
 use tokio_io::{AsyncWrite, AsyncRead, IoFuture};
@@ -261,6 +263,7 @@ impl CommandExt for process::Command {
 /// > done because futures in general take `drop` as a sign of cancellation, and
 /// > this `Child` is itself a future. If you'd like to run a process in the
 /// > background, though, you may use the `forget` method.
+#[derive(Debug)]
 pub struct Child {
     child: imp::Child,
     kill_on_drop: bool,
@@ -373,6 +376,14 @@ pub struct WaitWithOutput {
     inner: IoFuture<Output>,
 }
 
+impl fmt::Debug for WaitWithOutput {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("WaitWithOutput")
+            .field("inner", &"..")
+            .finish()
+    }
+}
+
 impl Future for WaitWithOutput {
     type Item = Output;
     type Error = io::Error;
@@ -387,6 +398,7 @@ impl Future for WaitWithOutput {
 /// This future is used to conveniently spawn a child and simply wait for its
 /// exit status. This future will resolves to the `ExitStatus` type in the
 /// standard library.
+#[derive(Debug)]
 pub struct StatusAsync {
     inner: Flatten<FutureResult<Child, io::Error>>,
 }
@@ -409,6 +421,14 @@ pub struct OutputAsync {
     inner: IoFuture<Output>,
 }
 
+impl fmt::Debug for OutputAsync {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("OutputAsync")
+            .field("inner", &"..")
+            .finish()
+    }
+}
+
 impl Future for OutputAsync {
     type Item = Output;
     type Error = io::Error;
@@ -423,6 +443,7 @@ impl Future for OutputAsync {
 /// This type implements the `Write` trait to pass data to the stdin handle of
 /// a child process. Note that this type is also "futures aware" meaning that it
 /// is both (a) nonblocking and (b) will panic if used off of a future's task.
+#[derive(Debug)]
 pub struct ChildStdin {
     inner: imp::ChildStdin,
 }
@@ -433,6 +454,7 @@ pub struct ChildStdin {
 /// of a child process. Note that this type is also "futures aware" meaning
 /// that it is both (a) nonblocking and (b) will panic if used off of a
 /// future's task.
+#[derive(Debug)]
 pub struct ChildStdout {
     inner: imp::ChildStdout,
 }
@@ -443,6 +465,7 @@ pub struct ChildStdout {
 /// of a child process. Note that this type is also "futures aware" meaning
 /// that it is both (a) nonblocking and (b) will panic if used off of a
 /// future's task.
+#[derive(Debug)]
 pub struct ChildStderr {
     inner: imp::ChildStderr,
 }
@@ -485,6 +508,7 @@ impl AsyncRead for ChildStderr {
 
 #[deprecated(note = "use std::process::Command instead")]
 #[allow(deprecated, missing_docs)]
+#[allow(deprecated, missing_debug_implementations, missing_docs)]
 #[doc(hidden)]
 pub struct Command {
     inner: process::Command,
@@ -493,7 +517,7 @@ pub struct Command {
 }
 
 #[deprecated(note = "use std::process::Command instead")]
-#[allow(deprecated, missing_docs)]
+#[allow(deprecated, missing_debug_implementations, missing_docs)]
 #[doc(hidden)]
 pub struct Spawn {
     inner: Box<Future<Item=Child, Error=io::Error>>,

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -36,6 +36,7 @@ use mio::event::Evented;
 use mio;
 use self::libc::c_int;
 use self::tokio_signal::unix::Signal;
+use std::fmt;
 use tokio_io::IoFuture;
 use tokio_core::reactor::{Handle, PollEvented};
 
@@ -43,6 +44,17 @@ pub struct Child {
     inner: process::Child,
     reaped: bool,
     sigchld: FlattenStream<IoFuture<Signal>>,
+}
+
+impl fmt::Debug for Child {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Child")
+            .field("pid", &self.inner.id())
+            .field("inner", &self.inner)
+            .field("reaped", &self.reaped)
+            .field("sigchld", &"..")
+            .finish()
+    }
 }
 
 impl Child {
@@ -125,6 +137,7 @@ impl Child {
     }
 }
 
+#[derive(Debug)]
 pub struct Fd<T>(T);
 
 impl<T: io::Read> io::Read for Fd<T> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -19,6 +19,7 @@ extern crate winapi;
 extern crate kernel32;
 extern crate mio_named_pipes;
 
+use std::fmt;
 use std::io;
 use std::os::windows::prelude::*;
 use std::os::windows::process::ExitStatusExt;
@@ -33,6 +34,16 @@ use tokio_core::reactor::{PollEvented, Handle};
 pub struct Child {
     child: process::Child,
     waiting: Option<Waiting>,
+}
+
+impl fmt::Debug for Child {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Child")
+            .field("pid", &self.id())
+            .field("child", &self.child)
+            .field("waiting", &"..")
+            .finish()
+    }
 }
 
 struct Waiting {


### PR DESCRIPTION
* All non-deprecated strucs now implement `Debug` and will display the
debug versions of their fields as best as possible
* For trait objects or externally defined structs which don't implement
`Debug` a placeholder ".." has been used in the event it can be
expanded later
* There are a few trait object/boxed future placeholders that can potentially be unboxed and shown via `Debug`, but I didn't dive into how useful the debug context may or may not and decided to punt them for now