### PR TITLE
Add `status_async2` as a closer analog to `spawn_async`

### DIFF
--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -119,6 +119,7 @@ fn wait_with_output_captures() {
     assert_eq!(output.stderr.len(), 0);
 }
 
+#[allow(deprecated)]
 #[test]
 fn status_closes_any_pipes() {
     let mut core = Core::new().unwrap();
@@ -127,6 +128,24 @@ fn status_closes_any_pipes() {
     // If `status_async` doesn't ensure the handles are closed,
     // we would end up blocking forever (and time out).
     let child = cat().status_async(&core.handle());
+    let timeout = Timeout::new(Duration::from_secs(1), &core.handle())
+        .expect("timeout registration failed")
+        .map(|()| panic!("time out exceeded! did we get stuck waiting on the child?"));
+
+    match core.run(child.select(timeout)) {
+        Ok((status, _)) => assert!(status.success()),
+        Err(_) => panic!("failed to run futures"),
+    }
+}
+
+#[test]
+fn status2_closes_any_pipes() {
+    let mut core = Core::new().unwrap();
+
+    // Cat will open a pipe between the parent and child.
+    // If `status_async2` doesn't ensure the handles are closed,
+    // we would end up blocking forever (and time out).
+    let child = cat().status_async2(&core.handle()).unwrap();
     let timeout = Timeout::new(Duration::from_secs(1), &core.handle())
         .expect("timeout registration failed")
         .map(|()| panic!("time out exceeded! did we get stuck waiting on the child?"));


### PR DESCRIPTION
* `spawn_async` allows the caller to immediately determine if the spawn
succeeded or failed without having to poll the `Child` handle.
`status_async` hides this result until it gets polled
* `status_async2` offers a closer analog to `spawn_async` while still
simplifying the prep work to ensure waiting on the child doesn't
deadlock due to the parent holding any pipe handles to the child
* Open to bikeshedding the `status_async2` name, using the lazy name due to lack of creativity
* ~~Seems like we can deprecate `status_async` without losing much, but did not mark it as such yet in case it's actually useful to have both methods~~
* `status_async`/`StatusAsync` have been marked as deprecated