### PR TITLE
fix zombification on Drop on unix

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -90,7 +90,11 @@ impl Child {
         if self.reaped {
             Ok(())
         } else {
-            self.inner.kill()
+            self.inner.kill()?;
+            let mut status = 0;
+            let id = self.id() as c_int;
+            unsafe { libc::waitpid(id, &mut status, 0) };
+            Ok(())
         }
     }
 


### PR DESCRIPTION
fixes #32

call waitpid blocking after kill.
Otherwise the process will never be reaped, because the code to reap it is already dropped.

SIGKILL cannnot be caught, so the process will definitely exit immediately.
We're not waiting for the process itself but for the kernel to execute the kill.