### PR TITLE
Bump to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- **Breaking**: asynchronous spawning of a child process now requires using a
+reactor handle from the `tokio` crate instead of the `tokio-core` crate
+- Child processes may be spawned without specifying a `tokio` handle at all
+(the current/default reactor handle will be used)
+### Removed
+- **Breaking**: removed all previously deprecated items
+
+## [0.1.6] - 2018-05-09
+### Fixed
+- On Unix systems, any child processes that are `kill`ed (or implicitly killed
+via dropping the child without calling `forget`) are no longer left in a zombie
+state, which allows the OS to reclaim the process.
+
+## [0.1.5] - 2018-01-03
+### Changed
+- Minimum required version of `winapi` has been bumped to `0.3`.
+
+## [0.1.4] - 2017-06-25
+### Fixed
+- Added missing `Debug` impls on all types.
+- Added missing `must_use` annotations on all futures.
+- Ensure `status_async` closes child's stdio handles after spawning in order
+to prevent potential deadlocks when attempting to interact with any pipes held
+by the parent process.
+
+## [0.1.3] - 2017-03-15
+### Changed
+- Minimum required version of `futures` has been bumped to `0.1.11`.
+- Minimum required version of `mio` has been bumped to `0.6.5`.
+- Minimum required version of `tokio-core` has been bumped to `0.1.6`.
+
+## [0.1.2] - 2017-01-24
+### Changed
+- Minimum required version of `tokio-signal` has been bumped to `0.1.2`.
+### Fixed
+- The event loop which spawns the first async child no longer needs to be kept
+alive for subsequent child spawns to make progress.
+
+## [0.1.1] - 2016-12-19
+### Added
+- Support performing async I/O operations on the child's stdio handles.
+### Changed
+- Functionality has been reimplemented as the `CommandExt` extension trait
+(implemented directly on `std::process::Command`) instead of going through
+the locally vendored `Command` type.
+
+## 0.1.0 - 2016-09-10
+- First release!
+
+[Unreleased]: https://github.com/alexcrichton/tokio-process/compare/0.1.6...HEAD
+[0.1.6]: https://github.com/alexcrichton/tokio-process/compare/0.1.5...0.1.6
+[0.1.5]: https://github.com/alexcrichton/tokio-process/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/alexcrichton/tokio-process/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/alexcrichton/tokio-process/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/alexcrichton/tokio-process/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/alexcrichton/tokio-process/compare/0.1.0...0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 2018-05-18
 ### Changed
 - **Breaking**: asynchronous spawning of a child process now requires using a
 reactor handle from the `tokio` crate instead of the `tokio-core` crate
@@ -55,7 +57,8 @@ the locally vendored `Command` type.
 ## 0.1.0 - 2016-09-10
 - First release!
 
-[Unreleased]: https://github.com/alexcrichton/tokio-process/compare/0.1.6...HEAD
+[Unreleased]: https://github.com/alexcrichton/tokio-process/compare/0.2.1...HEAD
+[0.2.1]: https://github.com/alexcrichton/tokio-process/compare/0.1.6...0.2.1
 [0.1.6]: https://github.com/alexcrichton/tokio-process/compare/0.1.5...0.1.6
 [0.1.5]: https://github.com/alexcrichton/tokio-process/compare/0.1.4...0.1.5
 [0.1.4]: https://github.com/alexcrichton/tokio-process/compare/0.1.3...0.1.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.1.11"
 mio = "0.6.5"
 tokio-core = "0.1.6"
 tokio-io = "0.1"
+tokio-reactor = "0.1"
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
@@ -43,4 +44,4 @@ features = [
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-tokio-signal = "0.1"
+tokio-signal = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ appveyor = { repository = "alexcrichton/tokio-process" }
 [dependencies]
 futures = "0.1.11"
 mio = "0.6.5"
-tokio-core = "0.1.6"
 tokio-io = "0.1"
 tokio-reactor = "0.1"
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
 log = "0.4"
+tokio = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 mio-named-pipes = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "tokio-process"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
-# - Create "vX.Y.Z" git tag.
-version = "0.1.6"
+# - Create "X.Y.Z" git tag.
+version = "0.2.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/tokio-process"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "tokio-process"
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update CHANGELOG.md.
+# - Create "vX.Y.Z" git tag.
 version = "0.1.6"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-process = "0.1.1"
+tokio-process = "0.2"
 ```
 
 Next, add this to your crate:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,27 +436,23 @@ impl Child {
     ///
     /// ```no_run
     /// # extern crate futures;
-    /// # extern crate tokio_core;
+    /// # extern crate tokio;
     /// # extern crate tokio_process;
     /// #
     /// # use std::process::Command;
     /// #
     /// # use futures::Future;
-    /// # use tokio_core::reactor::Core;
     /// # use tokio_process::CommandExt;
     /// #
     /// # fn main() {
-    /// let core = Core::new().unwrap();
-    /// let handle = core.handle();
-    ///
     /// let child = Command::new("echo").arg("hello").arg("world")
-    ///                     .spawn_async(&handle)
+    ///                     .spawn_async()
     ///                     .expect("failed to spawn");
     ///
     /// let do_cleanup = child.map(|_| ()) // Ignore result
     ///                       .map_err(|_| ()); // Ignore errors
     ///
-    /// handle.spawn(do_cleanup);
+    /// tokio::spawn(do_cleanup);
     /// # }
     /// ```
     pub fn forget(mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@
 
 #![warn(missing_debug_implementations)]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/tokio-process/0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-process/0.2")]
 
 extern crate futures;
 extern crate tokio_io;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -37,7 +37,7 @@ use mio;
 use self::tokio_signal::unix::Signal;
 use std::fmt;
 use tokio_io::IoFuture;
-use tokio_core::reactor::{Handle, PollEvented};
+use tokio_reactor::{Handle, PollEvented};
 
 #[must_use = "futures do nothing unless polled"]
 pub struct Child {
@@ -62,7 +62,7 @@ impl Child {
         Child {
             inner: inner,
             reaped: false,
-            sigchld: Signal::new(libc::SIGCHLD, handle).flatten_stream(),
+            sigchld: Signal::with_handle(libc::SIGCHLD, handle).flatten_stream(),
         }
     }
 
@@ -224,6 +224,6 @@ fn stdio<T>(option: Option<T>, handle: &Handle)
             return Err(io::Error::last_os_error())
         }
     }
-    let io = try!(PollEvented::new(Fd(io), handle));
+    let io = try!(PollEvented::new_with_handle(Fd(io), handle));
     Ok(Some(io))
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -36,7 +36,7 @@ use self::winapi::um::synchapi::*;
 use self::winapi::um::threadpoollegacyapiset::*;
 use self::winapi::um::winbase::*;
 use self::winapi::um::winnt::*;
-use tokio_core::reactor::{PollEvented, Handle};
+use tokio_reactor::{Handle, PollEvented};
 
 #[must_use = "futures do nothing unless polled"]
 pub struct Child {
@@ -182,6 +182,6 @@ fn stdio<T>(option: Option<T>, handle: &Handle)
         None => return Ok(None),
     };
     let pipe = unsafe { NamedPipe::from_raw_handle(io.into_raw_handle()) };
-    let io = try!(PollEvented::new(pipe, handle));
+    let io = try!(PollEvented::new_with_handle(pipe, handle));
     Ok(Some(io))
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -11,7 +11,7 @@ fn simple() {
     let mut lp = Core::new().unwrap();
     let mut cmd = support::cmd("exit");
     cmd.arg("2");
-    let mut child = cmd.spawn_async(&lp.handle()).unwrap();
+    let mut child = cmd.spawn_async_with_handle(lp.handle().new_tokio_handle()).unwrap();
     let id = child.id();
     assert!(id > 0);
     let status = lp.run(&mut child).unwrap();

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,21 +1,24 @@
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_process;
 
-use tokio_core::reactor::Core;
+use tokio::executor::current_thread;
 use tokio_process::CommandExt;
 
 mod support;
 
 #[test]
 fn simple() {
-    let mut lp = Core::new().unwrap();
     let mut cmd = support::cmd("exit");
     cmd.arg("2");
-    let mut child = cmd.spawn_async_with_handle(lp.handle().new_tokio_handle()).unwrap();
+
+    let mut child = cmd.spawn_async().unwrap();
+
     let id = child.id();
     assert!(id > 0);
-    let status = lp.run(&mut child).unwrap();
+
+    let status = current_thread::block_on_all(&mut child).unwrap();
     assert_eq!(status.code(), Some(2));
+
     assert_eq!(child.id(), id);
     drop(child.kill());
 }

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -120,13 +120,13 @@ fn wait_with_output_captures() {
 }
 
 #[test]
-fn status2_closes_any_pipes() {
+fn status_closes_any_pipes() {
     let mut core = Core::new().unwrap();
 
     // Cat will open a pipe between the parent and child.
-    // If `status_async2` doesn't ensure the handles are closed,
+    // If `status_async` doesn't ensure the handles are closed,
     // we would end up blocking forever (and time out).
-    let child = cat().status_async2(&core.handle()).unwrap();
+    let child = cat().status_async(&core.handle()).unwrap();
     let timeout = Timeout::new(Duration::from_secs(1), &core.handle())
         .expect("timeout registration failed")
         .map(|()| panic!("time out exceeded! did we get stuck waiting on the child?"));

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -119,25 +119,6 @@ fn wait_with_output_captures() {
     assert_eq!(output.stderr.len(), 0);
 }
 
-#[allow(deprecated)]
-#[test]
-fn status_closes_any_pipes() {
-    let mut core = Core::new().unwrap();
-
-    // Cat will open a pipe between the parent and child.
-    // If `status_async` doesn't ensure the handles are closed,
-    // we would end up blocking forever (and time out).
-    let child = cat().status_async(&core.handle());
-    let timeout = Timeout::new(Duration::from_secs(1), &core.handle())
-        .expect("timeout registration failed")
-        .map(|()| panic!("time out exceeded! did we get stuck waiting on the child?"));
-
-    match core.run(child.select(timeout)) {
-        Ok((status, _)) => assert!(status.success()),
-        Err(_) => panic!("failed to run futures"),
-    }
-}
-
 #[test]
 fn status2_closes_any_pipes() {
     let mut core = Core::new().unwrap();

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -1,5 +1,5 @@
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_io;
 extern crate tokio_process;
 #[macro_use]
@@ -9,12 +9,14 @@ extern crate env_logger;
 use std::io;
 use std::process::{Stdio, ExitStatus, Command};
 use std::time::Duration;
+use std::time::Instant;
 
 use futures::future::Future;
 use futures::stream::{self, Stream};
+use tokio::executor::current_thread;
 use tokio_io::io::{read_until, write_all, read_to_end};
-use tokio_core::reactor::{Core, Timeout};
 use tokio_process::{CommandExt, Child};
+use tokio::timer::Deadline;
 
 mod support;
 
@@ -84,34 +86,35 @@ fn feed_cat(mut cat: Child, n: usize) -> Box<Future<Item = ExitStatus, Error = i
 ///
 /// - The child does produce EOF on stdout after the last line.
 fn feed_a_lot() {
-    let mut lp = Core::new().unwrap();
-    let child = cat().spawn_async_with_handle(lp.handle().new_tokio_handle()).unwrap();
-    let status = lp.run(feed_cat(child, 10000)).unwrap();
+    let child = cat().spawn_async().unwrap();
+    let status = current_thread::block_on_all(feed_cat(child, 10000)).unwrap();
     assert_eq!(status.code(), Some(0));
 }
 
 #[test]
 fn drop_kills() {
-    let mut lp = Core::new().unwrap();
-    let mut child = cat().spawn_async_with_handle(lp.handle().new_tokio_handle()).unwrap();
+    let mut child = cat().spawn_async().unwrap();
     let stdin = child.stdin().take().unwrap();
     let stdout = child.stdout().take().unwrap();
     drop(child);
 
-    drop(lp.run(write_all(stdin, b"1234")));
-    let (_, output) = lp.run(read_to_end(stdout, Vec::new())).unwrap();
+    // Ignore all write errors since we expect a broken pipe here
+    let writer = write_all(stdin, b"1234").then(|_| Ok(()));
+    let reader = read_to_end(stdout, Vec::new());
+
+    let future = writer.join(reader).map(|(_, (_, out))| out);
+
+    let output = current_thread::block_on_all(future).unwrap();
     assert_eq!(output.len(), 0);
 }
 
 #[test]
 fn wait_with_output_captures() {
-    let mut core = Core::new().unwrap();
-
-    let mut child = cat().spawn_async_with_handle(core.handle().new_tokio_handle()).unwrap();
+    let mut child = cat().spawn_async().unwrap();
     let stdin = child.stdin().take().unwrap();
     let out = child.wait_with_output();
 
-    let ret = core.run(write_all(stdin, b"1234").map(|p| p.1).join(out)).unwrap();
+    let ret = current_thread::block_on_all(write_all(stdin, b"1234").map(|p| p.1).join(out)).unwrap();
     let (written, output) = ret;
 
     assert!(output.status.success());
@@ -121,18 +124,15 @@ fn wait_with_output_captures() {
 
 #[test]
 fn status_closes_any_pipes() {
-    let mut core = Core::new().unwrap();
-
     // Cat will open a pipe between the parent and child.
     // If `status_async` doesn't ensure the handles are closed,
     // we would end up blocking forever (and time out).
-    let child = cat().status_async_with_handle(core.handle().new_tokio_handle()).unwrap();
-    let timeout = Timeout::new(Duration::from_secs(1), &core.handle())
-        .expect("timeout registration failed")
-        .map(|()| panic!("time out exceeded! did we get stuck waiting on the child?"));
+    let child = cat().status_async().expect("failed to spawn child");
 
-    match core.run(child.select(timeout)) {
-        Ok((status, _)) => assert!(status.success()),
-        Err(_) => panic!("failed to run futures"),
-    }
+    // NB: Deadline requires a timer registration which is provided by
+    // tokio's `current_thread::Runtime`, but isn't available by just using
+    // tokio's default CurrentThread executor which powers `current_thread::block_on_all`.
+    let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
+    rt.block_on(Deadline::new(child, Instant::now() + Duration::from_secs(1)))
+        .expect("time out exceeded! did we get stuck waiting on the child?");
 }

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -85,7 +85,7 @@ fn feed_cat(mut cat: Child, n: usize) -> Box<Future<Item = ExitStatus, Error = i
 /// - The child does produce EOF on stdout after the last line.
 fn feed_a_lot() {
     let mut lp = Core::new().unwrap();
-    let child = cat().spawn_async(&lp.handle()).unwrap();
+    let child = cat().spawn_async_with_handle(lp.handle().new_tokio_handle()).unwrap();
     let status = lp.run(feed_cat(child, 10000)).unwrap();
     assert_eq!(status.code(), Some(0));
 }
@@ -93,7 +93,7 @@ fn feed_a_lot() {
 #[test]
 fn drop_kills() {
     let mut lp = Core::new().unwrap();
-    let mut child = cat().spawn_async(&lp.handle()).unwrap();
+    let mut child = cat().spawn_async_with_handle(lp.handle().new_tokio_handle()).unwrap();
     let stdin = child.stdin().take().unwrap();
     let stdout = child.stdout().take().unwrap();
     drop(child);
@@ -107,7 +107,7 @@ fn drop_kills() {
 fn wait_with_output_captures() {
     let mut core = Core::new().unwrap();
 
-    let mut child = cat().spawn_async(&core.handle()).unwrap();
+    let mut child = cat().spawn_async_with_handle(core.handle().new_tokio_handle()).unwrap();
     let stdin = child.stdin().take().unwrap();
     let out = child.wait_with_output();
 
@@ -126,7 +126,7 @@ fn status_closes_any_pipes() {
     // Cat will open a pipe between the parent and child.
     // If `status_async` doesn't ensure the handles are closed,
     // we would end up blocking forever (and time out).
-    let child = cat().status_async(&core.handle()).unwrap();
+    let child = cat().status_async_with_handle(core.handle().new_tokio_handle()).unwrap();
     let timeout = Timeout::new(Duration::from_secs(1), &core.handle())
         .expect("timeout registration failed")
         .map(|()| panic!("time out exceeded! did we get stuck waiting on the child?"));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,6 +1,5 @@
 extern crate env_logger;
 extern crate futures;
-extern crate tokio_core;
 extern crate tokio_process;
 
 use std::env;


### PR DESCRIPTION
* Rebased the `0.2.x` branch on to `master`
* Bumped version to `0.2.1` and updated docs/references
* Planning on releasing to crates.io later this week if there are no major issues raised until then

r? @alexcrichton 