### PR TITLE
Bump min supported rustc version to 1.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.21.0
+    - rust: 1.25.0
     - rust: stable
     - os: osx
     - rust: beta


### PR DESCRIPTION
* The latest dependency closure includes crossbeam-utils 0.5.0 which
requires the `#[repr(align)]` feature which was stabilized in rust 1.25

cc @alexcrichton 