### PR TITLE
Implement AsRawFd for ChildStd* structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,3 +619,27 @@ impl Read for ChildStderr {
 
 impl AsyncRead for ChildStderr {
 }
+
+#[cfg(unix)]
+mod sys {
+    use std::os::unix::io::{AsRawFd, RawFd};
+    use super::{ChildStdin, ChildStdout, ChildStderr};
+
+    impl AsRawFd for ChildStdin {
+        fn as_raw_fd(&self) -> RawFd {
+            self.inner.get_ref().as_raw_fd()
+        }
+    }
+
+    impl AsRawFd for ChildStdout {
+        fn as_raw_fd(&self) -> RawFd {
+            self.inner.get_ref().as_raw_fd()
+        }
+    }
+
+    impl AsRawFd for ChildStderr {
+        fn as_raw_fd(&self) -> RawFd {
+            self.inner.get_ref().as_raw_fd()
+        }
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -195,6 +195,12 @@ impl<T: io::Write> io::Write for Fd<T> {
     }
 }
 
+impl<T> AsRawFd for Fd<T> where T: AsRawFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
 pub type ChildStdin = PollEvented<Fd<process::ChildStdin>>;
 pub type ChildStdout = PollEvented<Fd<process::ChildStdout>>;
 pub type ChildStderr = PollEvented<Fd<process::ChildStderr>>;
@@ -206,10 +212,10 @@ impl<T> Evented for Fd<T> where T: AsRawFd {
                 interest: Ready,
                 opts: PollOpt)
                 -> io::Result<()> {
-        EventedFd(&self.0.as_raw_fd()).register(poll,
-                                                token,
-                                                interest | UnixReady::hup(),
-                                                opts)
+        EventedFd(&self.as_raw_fd()).register(poll,
+                                              token,
+                                              interest | UnixReady::hup(),
+                                              opts)
     }
 
     fn reregister(&self,
@@ -218,14 +224,14 @@ impl<T> Evented for Fd<T> where T: AsRawFd {
                   interest: Ready,
                   opts: PollOpt)
                   -> io::Result<()> {
-        EventedFd(&self.0.as_raw_fd()).reregister(poll,
-                                                  token,
-                                                  interest | UnixReady::hup(),
-                                                  opts)
+        EventedFd(&self.as_raw_fd()).reregister(poll,
+                                                token,
+                                                interest | UnixReady::hup(),
+                                                opts)
     }
 
     fn deregister(&self, poll: &mio::Poll) -> io::Result<()> {
-        EventedFd(&self.0.as_raw_fd()).deregister(poll)
+        EventedFd(&self.as_raw_fd()).deregister(poll)
     }
 }
 


### PR DESCRIPTION
This allows us to write low-level stuff such as sending child fds over Unix
domain socket. I don't think there was a reason to not expose fd values.
