### PR TITLE
Make Child stdio members public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,9 +350,18 @@ impl CommandExt for process::Command {
 pub struct Child {
     child: imp::Child,
     kill_on_drop: bool,
-    stdin: Option<ChildStdin>,
-    stdout: Option<ChildStdout>,
-    stderr: Option<ChildStderr>,
+
+    /// The handle for writing to the child's standard input (stdin), if it has
+    /// been captured.
+    pub stdin: Option<ChildStdin>,
+
+    /// The handle for reading from the child's standard output (stdout), if it
+    /// has been captured
+    pub stdout: Option<ChildStdout>,
+
+    /// The handle for reading from the child's standard error (stderr), if it
+    /// has been captured.
+    pub stderr: Option<ChildStderr>,
 }
 
 impl Child {


### PR DESCRIPTION
Allowing users to take owning references of the streams.

Not having these public is forcing very complex workarounds in my code. Is there a particular reason they are private - or just erring towards private by default? Note `std::process::Child` does have its stdio streams public.

One example: I would like to be able to `close(2)` a child process's stdin by dropping it. 