### PR TITLE
Enable code coverage via cargo-tarpaulin and codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       after_success:
         - travis-cargo --only nightly doc-upload
         - cargo tarpaulin -v --forward --out Xml
+        - bash <(curl -s https://codecov.io/bash)
 
 script:
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,22 @@ matrix:
     - rust: stable
     - os: osx
     - rust: beta
-    - rust: nightly
 
     - rust: nightly
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - libssl-dev
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+        - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
       script:
+        - cargo test
         - cargo doc --no-deps --all-features
       after_success:
         - travis-cargo --only nightly doc-upload
+        - cargo tarpaulin -v --forward --out Xml
 
 script:
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ matrix:
             - libssl-dev
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-        - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
       script:
         - cargo test
         - cargo doc --no-deps --all-features
       after_success:
         - travis-cargo --only nightly doc-upload
+        - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
         - cargo tarpaulin -v --forward --out Xml
         - bash <(curl -s https://codecov.io/bash)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["asynchronous"]
 [badges]
 travis-ci = { repository = "alexcrichton/tokio-process" }
 appveyor = { repository = "alexcrichton/tokio-process" }
+codecov = { repository = "alexcrichton/tokio-process" }
 
 [dependencies]
 futures = "0.1.11"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An implementation of process management for Tokio
 [![Build Status](https://travis-ci.org/alexcrichton/tokio-process.svg?branch=master)](https://travis-ci.org/alexcrichton/tokio-process)
 [![Build status](https://ci.appveyor.com/api/projects/status/43c8g7fy801e5902?svg=true)](https://ci.appveyor.com/project/alexcrichton/tokio-process)
 [![Crates.io](https://img.shields.io/crates/v/tokio-process.svg?maxAge=2592000)](https://crates.io/crates/tokio-process)
+[![Coverage](https://img.shields.io/codecov/c/github/alexcrichton/tokio-process/master.svg)](https://codecov.io/gh/alexcrichton/tokio-process)
 
 [Documentation](https://docs.rs/tokio-process)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+ignore:
+  - "src/bin"
+  - "tests"
+
+comment:
+  behavior: new


### PR DESCRIPTION
* Enable collecting and tracking code coverage of this crate.
  * I intend to do some internal refactoring later to make things more testable, and this will be a good way to track that progress.
* `cargo-tarpaulin` vs `kcov` coverage:
  * I've previously used `kcov` in other projects, but it requires a bit more manual setup and invocation while `cargo-tarpaulin` works easily out of the box (especially great for local testing/verification)
  * After briefly skimming the `cargo-tarpaulin` docs, it appears that it may have some missing features (like branch coverage).
  * I'm of the opinion that this isn't a huge blocker and we can revisit if it becomes an issue, but if anyone has any thoughts on this, I welcome your feedback!
* codecov vs coveralls
  * A long time ago I tried to compare codecov vs coveralls (the two most popular code coverage tracking tools used in the rust ecosystem).
  * I cannot remember why I chose codecov, but it works pretty well and has some nice PR integrations for gating approvals based on code coverage quality
  * Again if anyone happens to have specific suggestions around these vendors, I'm happy to read your feedback!

r? @alexcrichton 