### PR TITLE
Introduce a global queue of orphan process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
+crossbeam-queue = "0.1.2"
+lazy_static = "1.3"
 libc = "0.2"
+log = "0.4"
 mio = "0.6.5"
 tokio-signal = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ codecov = { repository = "alexcrichton/tokio-process" }
 
 [dependencies]
 futures = "0.1.11"
-mio = "0.6.5"
 tokio-io = "0.1"
 tokio-reactor = "0.1"
 
@@ -53,4 +52,5 @@ features = [
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+mio = "0.6.5"
 tokio-signal = "0.2.5"

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -1,0 +1,13 @@
+use std::io;
+
+/// An interface for killing a running process.
+pub(crate) trait Kill {
+    /// Forcefully kill the process.
+    fn kill(&mut self) -> io::Result<()>;
+}
+
+impl<'a, T: 'a + Kill> Kill for &'a mut T {
+    fn kill(&mut self) -> io::Result<()> {
+        (**self).kill()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,13 @@ extern crate futures;
 extern crate tokio_io;
 extern crate tokio_reactor;
 
+#[cfg(unix)]
+#[macro_use]
+extern crate lazy_static;
+#[cfg(unix)]
+#[macro_use]
+extern crate log;
+
 use std::io::{self, Read, Write};
 use std::process::{Command, ExitStatus, Output, Stdio};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,6 @@
 extern crate futures;
 extern crate tokio_io;
 extern crate tokio_reactor;
-extern crate mio;
 
 use std::io::{self, Read, Write};
 use std::process::{Command, ExitStatus, Output, Stdio};

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -84,7 +84,7 @@ impl OrphanQueue<process::Child> for GlobalOrphanQueue {
 
 #[must_use = "futures do nothing unless polled"]
 pub struct Child {
-    inner: Reaper<process::Child, FlattenStream<IoFuture<Signal>>>,
+    inner: Reaper<process::Child, GlobalOrphanQueue, FlattenStream<IoFuture<Signal>>>,
 }
 
 impl fmt::Debug for Child {
@@ -104,7 +104,7 @@ pub(crate) fn spawn_child(cmd: &mut process::Command, handle: &Handle) -> io::Re
     let signal = Signal::with_handle(libc::SIGCHLD, handle).flatten_stream();
     Ok(SpawnedChild {
         child: Child {
-            inner: Reaper::new(child, signal),
+            inner: Reaper::new(child, GlobalOrphanQueue, signal),
         },
         stdin,
         stdout,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -22,17 +22,16 @@
 //! bad in theory...
 
 extern crate libc;
+extern crate mio;
 extern crate tokio_signal;
 
 mod reap;
 
 use futures::future::FlattenStream;
 use futures::{Future, Poll};
-use mio::unix::{EventedFd, UnixReady};
-use mio::{PollOpt, Ready, Token};
-use mio::event::Evented;
-use mio;
-use self::reap::{Kill, Reaper, Wait};
+use self::mio::{Poll as MioPoll, PollOpt, Ready, Token};
+use self::mio::unix::{EventedFd, UnixReady};
+use self::mio::event::Evented;
 use self::tokio_signal::unix::Signal;
 use std::fmt;
 use std::io;
@@ -130,7 +129,7 @@ pub type ChildStderr = PollEvented<Fd<process::ChildStderr>>;
 
 impl<T> Evented for Fd<T> where T: AsRawFd {
     fn register(&self,
-                poll: &mio::Poll,
+                poll: &MioPoll,
                 token: Token,
                 interest: Ready,
                 opts: PollOpt)
@@ -142,7 +141,7 @@ impl<T> Evented for Fd<T> where T: AsRawFd {
     }
 
     fn reregister(&self,
-                  poll: &mio::Poll,
+                  poll: &MioPoll,
                   token: Token,
                   interest: Ready,
                   opts: PollOpt)
@@ -153,7 +152,7 @@ impl<T> Evented for Fd<T> where T: AsRawFd {
                                                 opts)
     }
 
-    fn deregister(&self, poll: &mio::Poll) -> io::Result<()> {
+    fn deregister(&self, poll: &MioPoll) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).deregister(poll)
     }
 }

--- a/src/unix/orphan.rs
+++ b/src/unix/orphan.rs
@@ -12,6 +12,16 @@ pub(crate) trait Wait {
     fn try_wait(&mut self) -> io::Result<Option<ExitStatus>>;
 }
 
+impl<'a, T: 'a + Wait> Wait for &'a mut T {
+    fn id(&self) -> u32 {
+        (**self).id()
+    }
+
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        (**self).try_wait()
+    }
+}
+
 /// An interface for queueing up an orphaned process so that it can be reaped.
 pub(crate) trait OrphanQueue<T> {
     /// Add an orphan to the queue.
@@ -19,6 +29,16 @@ pub(crate) trait OrphanQueue<T> {
     /// Attempt to reap every process in the queue, ignoring any errors and
     /// enqueueing any orphans which have not yet exited.
     fn reap_orphans(&self);
+}
+
+impl<'a, T, O: 'a + OrphanQueue<T>> OrphanQueue<T> for &'a O {
+    fn push_orphan(&self, orphan: T) {
+        (**self).push_orphan(orphan);
+    }
+
+    fn reap_orphans(&self) {
+        (**self).reap_orphans()
+    }
 }
 
 /// An atomic implementation of `OrphanQueue`.

--- a/src/unix/orphan.rs
+++ b/src/unix/orphan.rs
@@ -1,0 +1,173 @@
+extern crate crossbeam_queue;
+
+use self::crossbeam_queue::SegQueue;
+use std::io;
+use std::process::ExitStatus;
+
+/// An interface for waiting on a process to exit.
+pub(crate) trait Wait {
+    /// Get the identifier for this process or diagnostics.
+    fn id(&self) -> u32;
+    /// Try waiting for a process to exit in a non-blocking manner.
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>>;
+}
+
+/// An interface for queueing up an orphaned process so that it can be reaped.
+pub(crate) trait OrphanQueue<T> {
+    /// Add an orphan to the queue.
+    fn push_orphan(&self, orphan: T);
+    /// Attempt to reap every process in the queue, ignoring any errors and
+    /// enqueueing any orphans which have not yet exited.
+    fn reap_orphans(&self);
+}
+
+/// An atomic implementation of `OrphanQueue`.
+#[derive(Debug)]
+pub(crate) struct AtomicOrphanQueue<T> {
+    queue: SegQueue<T>,
+}
+
+impl<T> AtomicOrphanQueue<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            queue: SegQueue::new(),
+        }
+    }
+}
+
+impl<T: Wait> OrphanQueue<T> for AtomicOrphanQueue<T> {
+    fn push_orphan(&self, orphan: T) {
+        self.queue.push(orphan)
+    }
+
+    fn reap_orphans(&self) {
+        let len = self.queue.len();
+
+        if len == 0 {
+            return;
+        }
+
+        let mut orphans = Vec::with_capacity(len);
+        while let Ok(mut orphan) = self.queue.pop() {
+            match orphan.try_wait() {
+                Ok(Some(_)) => {},
+                Err(e) => error!(
+                    "leaking orphaned process {} due to try_wait() error: {}",
+                    orphan.id(),
+                    e,
+                ),
+
+                // Still not done yet, we need to put it back in the queue
+                // when were done draining it, so that we don't get stuck
+                // in an infinite loop here
+                Ok(None) => orphans.push(orphan),
+            }
+        }
+
+        for orphan in orphans {
+            self.queue.push(orphan);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::cell::Cell;
+    use std::io;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::ExitStatus;
+    use std::rc::Rc;
+    use super::{AtomicOrphanQueue, OrphanQueue};
+    use super::Wait;
+
+    struct MockWait {
+        total_waits: Rc<Cell<usize>>,
+        num_wait_until_status: usize,
+        return_err: bool,
+    }
+
+    impl MockWait {
+        fn new(num_wait_until_status: usize) -> Self {
+            Self {
+                total_waits: Rc::new(Cell::new(0)),
+                num_wait_until_status,
+                return_err: false,
+            }
+        }
+
+        fn with_err() -> Self {
+            Self {
+                total_waits: Rc::new(Cell::new(0)),
+                num_wait_until_status: 0,
+                return_err: true,
+            }
+        }
+    }
+
+    impl Wait for MockWait {
+        fn id(&self) -> u32 {
+            42
+        }
+
+        fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+            let waits = self.total_waits.get();
+
+            let ret = if self.num_wait_until_status == waits {
+                if self.return_err {
+                    Ok(Some(ExitStatus::from_raw(0)))
+                } else {
+                    Err(io::Error::new(io::ErrorKind::Other, "mock err"))
+                }
+            } else {
+                Ok(None)
+            };
+
+            self.total_waits.set(waits + 1);
+            ret
+        }
+    }
+
+    #[test]
+    fn drain_attempts_a_single_reap_of_all_queued_orphans() {
+        let first_orphan = MockWait::new(0);
+        let second_orphan = MockWait::new(1);
+        let third_orphan = MockWait::new(2);
+        let fourth_orphan = MockWait::with_err();
+
+        let first_waits = first_orphan.total_waits.clone();
+        let second_waits = second_orphan.total_waits.clone();
+        let third_waits = third_orphan.total_waits.clone();
+        let fourth_waits = fourth_orphan.total_waits.clone();
+
+        let orphanage = AtomicOrphanQueue::new();
+        orphanage.push_orphan(first_orphan);
+        orphanage.push_orphan(third_orphan);
+        orphanage.push_orphan(second_orphan);
+        orphanage.push_orphan(fourth_orphan);
+
+        assert_eq!(orphanage.queue.len(), 4);
+
+        orphanage.reap_orphans();
+        assert_eq!(orphanage.queue.len(), 2);
+        assert_eq!(first_waits.get(), 1);
+        assert_eq!(second_waits.get(), 1);
+        assert_eq!(third_waits.get(), 1);
+        assert_eq!(fourth_waits.get(), 1);
+
+        orphanage.reap_orphans();
+        assert_eq!(orphanage.queue.len(), 1);
+        assert_eq!(first_waits.get(), 1);
+        assert_eq!(second_waits.get(), 2);
+        assert_eq!(third_waits.get(), 2);
+        assert_eq!(fourth_waits.get(), 1);
+
+        orphanage.reap_orphans();
+        assert_eq!(orphanage.queue.len(), 0);
+        assert_eq!(first_waits.get(), 1);
+        assert_eq!(second_waits.get(), 2);
+        assert_eq!(third_waits.get(), 3);
+        assert_eq!(fourth_waits.get(), 1);
+
+        orphanage.reap_orphans(); // Safe to reap when empty
+    }
+}

--- a/src/unix/reap.rs
+++ b/src/unix/reap.rs
@@ -1,14 +1,9 @@
 use futures::{Async, Future, Poll, Stream};
+use kill::Kill;
 use std::io;
 use std::ops::Deref;
 use std::process::ExitStatus;
 use super::orphan::{OrphanQueue, Wait};
-
-/// An interface for killing a running process.
-pub(crate) trait Kill {
-    /// Forcefully kill the process.
-    fn kill(&mut self) -> io::Result<()>;
-}
 
 /// Orchestrates between registering interest for receiving signals when a
 /// child process has exited, and attempting to poll for process completion.


### PR DESCRIPTION
### Motivation
* Follow up to #55 
* According to #51 it is possible that a kill doesn't terminate the child immediately, so it is possible that we will leak child processes during the drop-kill prcedure
* Not reaping the process is also bad due to using up pids (even if we call `.forget()` today that pid doesn't get reaped as well)

### Changes
* Introduce a global queue of orphan process which we will attempt to reap at a later time

* If a child proces handle is dropped and the process has not yet been
reaped, it will be pushed into a global queue
* Whenever we try to poll (reap) a child process, we'll attempt to drain
the global queue as well (since we know a signal has been delivered, we
also check if the orphaned children have exited).
* This solution avoids the complexities of spawning a new task to reap
any orphans, but it may lead to some performance degredation for large
amounts of orphan proceses:
  - Pro: no need to deal with spawning a task on the current executor
  (e.g. what if we aren't even running in an executor?)
  - Pro: no need to deal with leaking the orphan reaper task (e.g. if
  the executor is dropped, we would leak the task and the orphan
  processes)
  - Pro: no need to deal with creating a new Signal stream (e.g. what if
  there is no reactor/what if the signal registration fails)
  - Con: every poll of a child process will also poll all orphans. If
  there are multiple child processes, each will attempt to drain the
  queue if running synchronously, which will perform redundant work
* Overall, creating orphan processes should be extremely rare and this
should hopefully not cause any practical performance degredations (minus
an extra atomic op during each poll)

Fixes #51 