### PR TITLE
Add warning that the code has been moved to the tokio repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## The tokio-process crate has been moved into the [tokio](https://github.com/tokio-rs/tokio) Git repository.
+
+Please do not use this repo anymore.
+
 # tokio-process
 
 An implementation of process management for Tokio


### PR DESCRIPTION
Hey @alexcrichton we've moved the `tokio-process` source to the main `tokio` repo!

We think this will be beneficial for the overall tokio ecosystem by testing and evolving the `tokio-process` crate alongside the rest of the official `tokio` crates. It will also make it easier to maintain with more eyes on the changes, which will also make contributes easier.

I've gone ahead and cleaned up any old PRs and migrated any previously open issues.
Could you merge this in and archive the repo for historical context?

Thanks again for writing and maintaining this crate!

Refs tokio-rs/tokio#1319